### PR TITLE
Remove ruby gems deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
+
 gemspec


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
