### PR TITLE
Remove deprecated alias_method_chain.

### DIFF
--- a/lib/easy_roles.rb
+++ b/lib/easy_roles.rb
@@ -4,8 +4,12 @@ module EasyRoles
   extend ActiveSupport::Concern
   
   included do |base|
-    base.send :alias_method_chain, :method_missing, :roles
-    base.send :alias_method_chain, :respond_to?, :roles
+    base.class_eval do
+      alias_method :method_missing_without_roles, :method_missing
+      alias_method :method_missing, :method_missing_with_roles
+      alias_method :respond_to_without_roles?, :respond_to?
+      alias_method :respond_to?, :respond_to_with_roles?
+    end
   end
 
   ALLOWED_METHODS = [:serialize, :bitmask]


### PR DESCRIPTION
Rails 6 requires this.